### PR TITLE
[style]/input, Selectbox#10

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,11 +15,13 @@ const nextConfig: NextConfig = {
     // ssr and displayName are configured by default
     styledComponents: true,
   },
-  turbopack: {
-    rules: {
-      '.svg': {
-        loaders: ['@svgr/webpack'],
-        as: '.js',
+  experimental: {
+    turbo: {
+      rules: {
+        '.svg': {
+          loaders: ['@svgr/webpack'],
+          as: '.js',
+        },
       },
     },
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,28 @@
-import { NextConfig } from "next";
+import { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  // output: 'export',
+  reactStrictMode: true,
+  webpack(config) {
+    config.module.rules.push({
+      test: /.svg$/,
+      use: ['@svgr/webpack'],
+    });
+
+    return config;
+  },
+  compiler: {
+    // ssr and displayName are configured by default
+    styledComponents: true,
+  },
   turbopack: {
     rules: {
-      '*.svg': {
+      '.svg': {
         loaders: ['@svgr/webpack'],
-        as: '*.js',
+        as: '.js',
       },
-    }
+    },
   },
-}
+};
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,29 +1,45 @@
-import { NextConfig } from 'next';
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  // output: 'export',
-  reactStrictMode: true,
-  webpack(config) {
-    config.module.rules.push({
-      test: /.svg$/,
-      use: ['@svgr/webpack'],
-    });
-
-    return config;
-  },
-  compiler: {
-    // ssr and displayName are configured by default
-    styledComponents: true,
-  },
+  // TurboPack 설정
   experimental: {
     turbo: {
       rules: {
-        '.svg': {
+        '*.svg': {
           loaders: ['@svgr/webpack'],
-          as: '.js',
+          as: '*.js',
         },
       },
     },
+  },
+  // webpack 설정
+  webpack: (config) => {
+    // @ts-expect-error 타입 에러 무시
+    const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.('.svg'));
+
+    config.module.rules.push(
+      {
+        ...fileLoaderRule,
+        test: /\.svg$/i,
+        resourceQuery: /url/,
+      },
+      {
+        test: /\.svg$/i,
+        issuer: fileLoaderRule.issuer,
+        resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /url/] },
+        use: [
+          {
+            loader: '@svgr/webpack',
+            options: {
+              typescript: true,
+              ext: 'tsx',
+            },
+          },
+        ],
+      }
+    );
+    fileLoaderRule.exclude = /\.svg$/i;
+    return config;
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx"
-  },
+  }, 
+  "include": ["svgr.d.ts", "next-env.d.ts", "src/**/*.d.ts"],
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",

--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -32,8 +32,7 @@ function Page() {
         <div className="space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">select</h3>
           {/* 여기 컴포넌트 삽입 */}
-          <SelectBox id='fruit' option={['논알콜','약한 도수','중간 도수']} title="도수"/>
-        
+          <SelectBox id="fruit" option={['논알콜', '약한 도수', '중간 도수']} title="도수" />
         </div>
       </div>
 

--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -32,7 +32,7 @@ function Page() {
         <div className="space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">select</h3>
           {/* 여기 컴포넌트 삽입 */}
-          <SelectBox id='id123'/>
+          <SelectBox id='fruit' option={['논알콜','약한 도수','중간 도수']} title="도수"/>
         
         </div>
       </div>

--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -2,6 +2,7 @@
 
 import Button from '@/shared/components/button/Button';
 import TextButton from '@/shared/components/button/TextButton';
+import Input from '@/shared/components/InputBox/Input';
 import ConfirmPop from '@/shared/components/ModalPop/ConfirmPop';
 import ModalLayout from '@/shared/components/ModalPop/ModalLayout';
 import { useState } from 'react';
@@ -22,13 +23,7 @@ function Page() {
         {/* Input */}
         <div className="flex flex-col gap-2 space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">Input</h3>
-          {/* 여기 컴포넌트 삽입 */}
-        </div>
-
-        {/* checkbox */}
-        <div className="space-y-2">
-          <h3 className="text-xl font-medium border-b pb-1">checkbox</h3>
-          {/* 여기 컴포넌트 삽입 */}
+          <Input placeholder='내용을 입력해주세요.'/>
         </div>
 
         {/* select */}

--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -32,7 +32,7 @@ function Page() {
         <div className="space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">select</h3>
           {/* 여기 컴포넌트 삽입 */}
-          <SelectBox id="fruit" option={['논알콜', '약한 도수', '중간 도수']} title="도수" />
+          <SelectBox id="fruit" option={['', '논알콜', '약한 도수', '중간 도수']} title="도수" />
         </div>
       </div>
 

--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -3,6 +3,7 @@
 import Button from '@/shared/components/button/Button';
 import TextButton from '@/shared/components/button/TextButton';
 import Input from '@/shared/components/InputBox/Input';
+import SelectBox from '@/shared/components/InputBox/SelectBox';
 import ConfirmPop from '@/shared/components/ModalPop/ConfirmPop';
 import ModalLayout from '@/shared/components/ModalPop/ModalLayout';
 import { useState } from 'react';
@@ -23,14 +24,16 @@ function Page() {
         {/* Input */}
         <div className="flex flex-col gap-2 space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">Input</h3>
-          <Input placeholder='내용을 입력해주세요.' />
-          <Input placeholder='칵테일을 검색해 보세요' size='lg'/>
+          <Input placeholder="내용을 입력해주세요." />
+          <Input placeholder="칵테일을 검색해 보세요" size="lg" />
         </div>
 
         {/* select */}
         <div className="space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">select</h3>
           {/* 여기 컴포넌트 삽입 */}
+          <SelectBox id='id123'/>
+        
         </div>
       </div>
 

--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -23,7 +23,8 @@ function Page() {
         {/* Input */}
         <div className="flex flex-col gap-2 space-y-2">
           <h3 className="text-xl font-medium border-b pb-1">Input</h3>
-          <Input placeholder='내용을 입력해주세요.'/>
+          <Input placeholder='내용을 입력해주세요.' />
+          <Input placeholder='칵테일을 검색해 보세요' size='lg'/>
         </div>
 
         {/* select */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,8 @@
-import Edit from '@/shared/assets/icons/edit_28.svg'
-
-
 export default function Home() {
   return (
     <div className="flex-center">
       <h1> 이게 기본</h1>
       <h1 className="font-serif">this is Serif</h1>
-      <Edit></Edit>
       <h1>테스트입니다</h1>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,12 @@
+import Edit from '@/shared/assets/icons/edit_28.svg'
+
+
 export default function Home() {
   return (
     <div className="flex-center">
       <h1> 이게 기본</h1>
       <h1 className="font-serif">this is Serif</h1>
+      <Edit></Edit>
       <h1>테스트입니다</h1>
     </div>
   );

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,4 +1,0 @@
-function index() {
-  return <button>버튼</button>;
-}
-export default index;

--- a/src/shared/components/InputBox/Input.tsx
+++ b/src/shared/components/InputBox/Input.tsx
@@ -26,7 +26,7 @@ export const InputClass = cva(
   }
 )
 
-function Input({placeholder,ref,size,className,...rest}: Props) {
+function Input({placeholder,ref,size,className,onChange,...rest}: Props) {
 
   return (
     <input
@@ -34,6 +34,7 @@ function Input({placeholder,ref,size,className,...rest}: Props) {
       className={tw(InputClass({ size, className }))}
       placeholder={placeholder}
       ref={ref}
+      onChange={onChange}
       {...rest}
     />
   )

--- a/src/shared/components/InputBox/Input.tsx
+++ b/src/shared/components/InputBox/Input.tsx
@@ -1,14 +1,13 @@
-import tw from "@/shared/utills/tw"
-import { cva } from "class-variance-authority"
-import { Ref } from "react"
+import tw from '@/shared/utills/tw';
+import { cva } from 'class-variance-authority';
+import { Ref } from 'react';
 
-
-interface Props{
-  placeholder: string,
-  ref?: Ref<HTMLInputElement | null>
-  size?: 'default' | 'lg'
-  className?: string
-  onChange?: () => void
+interface Props {
+  placeholder: string;
+  ref?: Ref<HTMLInputElement | null>;
+  size?: 'default' | 'lg';
+  className?: string;
+  onChange?: () => void;
 }
 
 export const InputClass = cva(
@@ -17,17 +16,16 @@ export const InputClass = cva(
     variants: {
       size: {
         default: 'h-10',
-        lg:'h-13'
-      }
+        lg: 'h-13',
+      },
     },
     defaultVariants: {
-      size:'default'
-    }
+      size: 'default',
+    },
   }
-)
+);
 
-function Input({placeholder,ref,size,className,onChange,...rest}: Props) {
-
+function Input({ placeholder, ref, size, className, onChange, ...rest }: Props) {
   return (
     <input
       type="text"
@@ -37,6 +35,6 @@ function Input({placeholder,ref,size,className,onChange,...rest}: Props) {
       onChange={onChange}
       {...rest}
     />
-  )
+  );
 }
-export default Input
+export default Input;

--- a/src/shared/components/InputBox/Input.tsx
+++ b/src/shared/components/InputBox/Input.tsx
@@ -7,7 +7,8 @@ interface Props{
   placeholder: string,
   ref?: Ref<HTMLInputElement | null>
   size?: 'default' | 'lg'
-  className?:string
+  className?: string
+  onChange?: () => void
 }
 
 export const InputClass = cva(
@@ -28,11 +29,12 @@ export const InputClass = cva(
 function Input({placeholder,ref,size,className,...rest}: Props) {
 
   return (
-    <input type="text"
+    <input
+      type="text"
       className={tw(InputClass({ size, className }))}
       placeholder={placeholder}
       ref={ref}
-      
+      {...rest}
     />
   )
 }

--- a/src/shared/components/InputBox/Input.tsx
+++ b/src/shared/components/InputBox/Input.tsx
@@ -1,0 +1,39 @@
+import tw from "@/shared/utills/tw"
+import { cva } from "class-variance-authority"
+import { Ref } from "react"
+
+
+interface Props{
+  placeholder: string,
+  ref?: Ref<HTMLInputElement | null>
+  size?: 'default' | 'lg'
+  className?:string
+}
+
+export const InputClass = cva(
+  `px-4 py-1 rounded-lg w-80 bg-white text-primary outline-none placeholder:text-gray-dark`,
+  {
+    variants: {
+      size: {
+        default: 'h-10',
+        lg:'h-13'
+      }
+    },
+    defaultVariants: {
+      size:'default'
+    }
+  }
+)
+
+function Input({placeholder,ref,size,className,...rest}: Props) {
+
+  return (
+    <input type="text"
+      className={tw(InputClass({ size, className }))}
+      placeholder={placeholder}
+      ref={ref}
+      
+    />
+  )
+}
+export default Input

--- a/src/shared/components/InputBox/SelectBox.tsx
+++ b/src/shared/components/InputBox/SelectBox.tsx
@@ -1,17 +1,16 @@
-import { Ref, useState } from "react";
-import Down from '@/shared/assets/icons/selectDown_24.svg'
+import { Ref, useState } from 'react';
+import Down from '@/shared/assets/icons/selectDown_24.svg';
 
-interface Props{
-  id: string
-  ref?: Ref<HTMLLabelElement | null>
-  option: string[]
-  title:string
+interface Props {
+  id: string;
+  ref?: Ref<HTMLLabelElement | null>;
+  option: string[];
+  title: string;
 }
 
-function SelectBox({ id, ref, option,title }: Props) {
-  
-const [isOpen,setIsOpen] = useState(false)
-const [select,setSelect] = useState('')
+function SelectBox({ id, ref, option, title }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [select, setSelect] = useState('');
   return (
     <div className="flex flex-col gap-2 relative h-6">
       <label
@@ -20,12 +19,19 @@ const [select,setSelect] = useState('')
         className="flex gap-2 cursor-pointer text-base"
         onClick={() => setIsOpen(!isOpen)}
       >
-       {select ? select : title}<Down />
+        {select ? select : title}
+        <Down />
       </label>
       {isOpen && (
         <ul className="w-30 bg-white text-gray-dark p-2 rounded-xl absolute top-8">
           {option.map((v, i) => (
-            <li key={v + i} className="cursor-pointer p-1 hover:bg-secondary" onClick={() => { setSelect(v), setIsOpen(!isOpen) }}>
+            <li
+              key={v + i}
+              className="cursor-pointer p-1 hover:bg-secondary"
+              onClick={() => {
+                (setSelect(v), setIsOpen(!isOpen));
+              }}
+            >
               {v}
             </li>
           ))}
@@ -34,4 +40,4 @@ const [select,setSelect] = useState('')
     </div>
   );
 }
-export default SelectBox
+export default SelectBox;

--- a/src/shared/components/InputBox/SelectBox.tsx
+++ b/src/shared/components/InputBox/SelectBox.tsx
@@ -1,0 +1,17 @@
+import { Ref } from "react";
+
+interface Props{
+  id: string
+  ref?: Ref<HTMLSelectElement | null>
+}
+
+function SelectBox({id,ref}:Props) {
+  return (
+    <>
+      <label htmlFor={id}>selectBox</label>
+
+      <select id={id} ref={ref}></select>
+    </>
+  );
+}
+export default SelectBox

--- a/src/shared/components/InputBox/SelectBox.tsx
+++ b/src/shared/components/InputBox/SelectBox.tsx
@@ -1,17 +1,37 @@
-import { Ref } from "react";
+import { Ref, useState } from "react";
+import Down from '@/shared/assets/icons/selectDown_24.svg'
 
 interface Props{
   id: string
-  ref?: Ref<HTMLSelectElement | null>
+  ref?: Ref<HTMLLabelElement | null>
+  option: string[]
+  title:string
 }
 
-function SelectBox({id,ref}:Props) {
+function SelectBox({ id, ref, option,title }: Props) {
+  
+const [isOpen,setIsOpen] = useState(false)
+const [select,setSelect] = useState('')
   return (
-    <>
-      <label htmlFor={id}>selectBox</label>
-
-      <select id={id} ref={ref}></select>
-    </>
+    <div className="flex flex-col gap-2 relative h-6">
+      <label
+        htmlFor={id}
+        ref={ref}
+        className="flex gap-2 cursor-pointer text-base"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+       {select ? select : title}<Down />
+      </label>
+      {isOpen && (
+        <ul className="w-30 bg-white text-gray-dark p-2 rounded-xl absolute top-8">
+          {option.map((v, i) => (
+            <li key={v + i} className="cursor-pointer p-1 hover:bg-secondary" onClick={() => { setSelect(v), setIsOpen(!isOpen) }}>
+              {v}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 export default SelectBox

--- a/src/shared/components/InputBox/SelectBox.tsx
+++ b/src/shared/components/InputBox/SelectBox.tsx
@@ -11,6 +11,16 @@ interface Props {
 function SelectBox({ id, ref, option, title }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [select, setSelect] = useState('');
+
+  const handleChoose = (v: string) => {
+    setIsOpen(!isOpen);
+    if (!v) {
+      setSelect(title);
+    } else {
+      setSelect(v);
+    }
+  };
+
   return (
     <div className="flex flex-col gap-2 relative h-6">
       <label
@@ -28,11 +38,9 @@ function SelectBox({ id, ref, option, title }: Props) {
             <li
               key={v + i}
               className="cursor-pointer p-1 hover:bg-secondary"
-              onClick={() => {
-                (setSelect(v), setIsOpen(!isOpen));
-              }}
+              onClick={() => handleChoose(v)}
             >
-              {v}
+              {v || title}
             </li>
           ))}
         </ul>

--- a/src/shared/components/button/Button.tsx
+++ b/src/shared/components/button/Button.tsx
@@ -20,7 +20,7 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 export const ButtonClass = cva(
   `
-  py-1 px-2 rounded-lg text-base font-bold flex-center text-bold text-navy duration-300 disabled:bg-gray disabled:cursor-not-allowed disabled:text-primary
+  py-1 px-2 rounded-lg text-base flex-center text-navy duration-300 disabled:bg-gray disabled:cursor-not-allowed disabled:text-primary
   `,
   {
     variants: {

--- a/src/shared/styles/_base.css
+++ b/src/shared/styles/_base.css
@@ -2,4 +2,8 @@
   button {
     cursor: pointer;
   }
+
+  select{
+    appearance:none
+  }
 }


### PR DESCRIPTION
## 📢 기능 설명

#### **input컴포넌트**
  placeholder: string; : placeholder 내용
  ref?: Ref<HTMLInputElement | null>;  :필요시 ref
  size?: 'default' | 'lg';  : 인풋창 사이즈 기본값 =default
  className?: string; : 추가 className
  onChange?: () => void; : 필요시 onChange함수 사용

---

#### **Select컴포넌트**
 id: string; : htmlFor id값
  ref?: Ref<HTMLLabelElement | null>; : 필요시 Ref
  option: string[]; :드롭다운 메뉴에 들어갈 아이템 **반드시** 첫 인덱스값은 비워둘 것 ( 그래야 초기화 상태 설정가능)
  title: string; : 드롭다운 초기 상태

---

Select컴포넌트 경우 

원하는 건 **셀렉트 박스 UI 자체는 평소에 보이지 않다가, 라벨을 누르는 순간 바로 “드롭다운 옵션 목록”이 열려야 한다**는 거죠. 그런데 네이티브 `<select>`는 **열림/닫힘을 JS로 직접 제어할 수 없습니다.** 그래서 라벨 클릭 → 셀렉트 DOM 생성 → 다시 셀렉트를 한 번 더 클릭해야 옵션이 열리는 문제가 생기는 거예요.

👉 즉, 네이티브 `<select>`로는 “라벨 클릭만으로 옵션창 열기”는 불가능합니다.


위와 같은 문제가 있어 `ul`을 사용한 드롭박스를 만들었습니다.

아마 서버에서 API를 받아옴에 따라 조금 변경 될 수있을것같습니다.

그리고 `option`을 일반 flex로 할 시 아래 컨텐츠가 밀려서 positin속성을 사용하여 붙여두었습니다.

디자인 파일에는 초기값 설정이 없지만 필터링을 초기화 하고 싶을 경우도 있다고 생각하여 초기값 설정을 두었습니다.

title props도 option[0]으로 해도 될 것 같긴한데 추후 데이터가 어떻게 들어오는 지 확인 후 변경하겠습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #10 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 접근성 면에서 괜찮은지
- [ ] 커스텀 드롭박스로 사용하였기 떄문에 모바일 환경에서 문제가 있을 것같은데 모바일 환경을 고려하여 드롭박스를 두가지 버전으로 만들어야 하는지 고민입니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
